### PR TITLE
Fixed to generate classes documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -280,7 +280,7 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # Note that for custom extensions you also need to set FILE_PATTERNS otherwise
 # the files are not read by doxygen.
 
-EXTENSION_MAPPING      =
+EXTENSION_MAPPING      = pm=C++
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable


### PR DESCRIPTION
Hi Ari, it seems that current(at least 1.8.13+) doxygen requires this patch to generate correctly classes documentation. 